### PR TITLE
fix timeout, fix sending jammed.

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ func ticker(ctx context.Context, wg *sync.WaitGroup, c *config.Config, queue *ma
 			rawMetrics, err := collector.Do(ctx, c)
 			if err != nil {
 				log.Println(err.Error())
+				return
 			}
 			if !c.DryRun {
 				queue.Enqueue(rawMetrics)

--- a/snmp/handler.go
+++ b/snmp/handler.go
@@ -28,7 +28,7 @@ func NewHandler(ctx context.Context, target, community string) Handler {
 			Transport:          "udp",
 			Community:          community,
 			Version:            gosnmp.Version2c,
-			Timeout:            time.Duration(2) * time.Second,
+			Timeout:            time.Duration(10) * time.Second,
 			Retries:            3,
 			ExponentialTimeout: true,
 			MaxOids:            gosnmp.MaxOids,


### PR DESCRIPTION
- タイムアウトが短すぎる場合があり、従来と同様の値に戻す
- エラーの際にreturn漏れしており、送信処理が詰まってしまう不具合を修正